### PR TITLE
Readds gun safeties

### DIFF
--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -215,6 +215,12 @@ GLOBAL_LIST_INIT(mystery_magic, list(
 			if(!instantiated_ballistic.internal_magazine)
 				var/obj/item/ammo_box/magazine/extra_mag = new instantiated_ballistic.spawn_magazine_type(loc)
 				user.put_in_hands(extra_mag)
+		// BUG EDIT START
+		var/datum/component/gun_safety/safety = instantiated_gun.GetExactComponent(/datum/component/gun_safety)
+		if(safety)
+			safety.safety_currently_on = FALSE
+			safety.update_action_button_state()
+		// BUG EDIT END
 
 	user.visible_message(span_notice("[user] takes [presented_item] from [src]."), span_notice("You take [presented_item] from [src]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	playsound(src, grant_sound, 70, FALSE, channel = current_sound_channel, falloff_exponent = 10)

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -730,6 +730,7 @@
 /datum/outfit/deathmatch_loadout/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
 	for(var/obj/item/gun/gun in user.get_all_contents())
 		var/datum/component/gun_safety/safety = gun.GetExactComponent(/datum/component/gun_safety)
-		safety.safety_currently_on = FALSE
-		safety.update_action_button_state()
+		if(safety)
+			safety.safety_currently_on = FALSE
+			safety.update_action_button_state()
 // BUG EDIT END

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -725,3 +725,11 @@
 		/obj/item/knife/butcher,
 		/obj/item/sharpener,
 	)
+
+// BUG EDIT START
+/datum/outfit/deathmatch_loadout/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+	for(var/obj/item/gun/gun in user.get_all_contents())
+		var/datum/component/gun_safety/safety = gun.GetExactComponent(/datum/component/gun_safety)
+		safety.safety_currently_on = FALSE
+		safety.update_action_button_state()
+// BUG EDIT END

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -77,6 +77,16 @@
 		if(istype(thing, /obj/effect/landmark/deathmatch_player_spawn))
 			player_spawns += thing
 
+	// BUG EDIT START
+	for(var/thing in atoms)
+		if(istype(thing, /obj/item/gun))
+			var/obj/item/gun/gun = thing
+			var/datum/component/gun_safety/safety = gun.GetExactComponent(/datum/component/gun_safety)
+			if(safety)
+				safety.safety_currently_on = FALSE
+				safety.update_action_button_state()
+	// BUG EDIT END
+
 	UnregisterSignal(source, COMSIG_LAZY_TEMPLATE_LOADED)
 	map.template_in_use = FALSE
 	addtimer(CALLBACK(src, PROC_REF(start_game_after_delay)), 8 SECONDS)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -82,7 +82,7 @@
 		pin = new pin(src)
 
 	add_seclight_point()
-//	give_gun_safeties() // SKYRAT EDIT ADDITION - GUN SAFETIES //BUBBER EDIT REMOVAL
+	give_gun_safeties() // SKYRAT EDIT ADDITION - GUN SAFETIES
 	give_manufacturer_examine() // SKYRAT EDIT ADDITON - MANUFACTURER EXAMINE
 
 /obj/item/gun/Destroy()

--- a/modular_skyrat/modules/gun_safety/code/safety_additions.dm
+++ b/modular_skyrat/modules/gun_safety/code/safety_additions.dm
@@ -33,6 +33,7 @@
 /obj/item/gun/energy/give_gun_safeties()
 	AddComponent(/datum/component/gun_safety)
 
+/* BUG EDIT START
 /obj/item/gun/energy/plasmacutter/give_gun_safeties()
 	return
 
@@ -43,3 +44,4 @@
 
 /obj/item/gun/syringe/blowgun/give_gun_safeties()
 	return
+BUG EDIT END */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Readds gun safeties, adds gun safeties to plasma cutters, KAs, and syringe guns, turns off safeties on deathmatch guns by default
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Readded gun safeties
add: Added safeties to plasma cutters, KAs, and syringe guns
qol: Deathmatch guns have safeties off by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
